### PR TITLE
Rollback versions if different channel that's behind

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -290,7 +290,24 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(function(versions) {
         // Update needed?
         var latest = _.first(versions);
-        if (!latest) throw new Error("Version not found");
+        if (!latest) {
+            // If there's no version, it's because this client was on a different
+            // channel previously, and the version was ahead of this one. We
+            // need to bump it back to the latest version on this channel.
+            platform = platforms.detect(platform);
+
+            // Build another promise which resolves to the latest version
+            return that.versions.filter({
+                tag: 'latest',
+                platform: platform,
+                channel: channel
+            }).then(function(versions) {
+                return _.first(versions);
+            });
+        }
+        return latest;
+    })
+    .then(function(latest) {
 
         // File exists
         var asset = _.find(latest.platforms, {


### PR DESCRIPTION
Scenario:
* Clinic is on voltorb which is on v2.0.28
* Clinic upgrades to `newsidebar`, which is v2.1.35
* Clinic changes back to voltorb
* Hits the update endpoint `update/channel/voltorb/win32/2.1.35/RELEASES`

Because 2.1.35 is greater than the highest voltorb version, it freaks out. You're not supposed to have a higher version than the highest one out there.

In our case, this is OK, and it should still issue an update, but for the other channel's latest version.